### PR TITLE
test(parser): fix test failure introduced by adding >= operator

### DIFF
--- a/promql/parser/parse_test.go
+++ b/promql/parser/parse_test.go
@@ -1799,11 +1799,11 @@ var testExpr = []struct {
 		errMsg: "unexpected character inside braces: '*'",
 	},
 	{
-		input: `foo{a>="b"}`,
+		input: `foo{a$="b"}`,
 		fail:  true,
 		// TODO(fabxc): willingly lexing wrong tokens allows for more precise error
 		// messages from the parser - consider if this is an option.
-		errMsg: "unexpected character inside braces: '>'",
+		errMsg: "unexpected character inside braces: '$'",
 	},
 	{
 		input:  "some_metric{a=\"\xff\"}",


### PR DESCRIPTION
The test failed with:
Error:      	An error is expected but got nil.
Test:       	TestParseExpressions/foo{a>="b"}

The original author of the test had arbitrarily chosen >= as an invalid
token; us introducing >= as a valid operator consequently broke that
test.