### PR TITLE
improve(engine): update handling of calls for label_replace, etc. when deriving grouping hints

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1030,7 +1030,7 @@ func extractGroupsFromPath(p []parser.Node) (int, bool, string, []string) {
 }
 
 // extractTransformedLabelsFromFuncs extracts additional grouping hints from the path starting at the most inner
-// aggregation to allow our synthetic metrics to correctly materialize the required labels
+// aggregation to allow our synthetic metrics to correctly materialize the required labels.
 func extractTransformedLabelsFromFuncs(p []parser.Node) map[string][]string {
 	var (
 		destinations []string

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1063,10 +1063,10 @@ func extractTransformedLabelsFromFuncs(p []parser.Node) map[string][]string {
 				}
 
 				if len(dst) > 0 && len(src) > 0 && !slices.Contains(destinations, src) {
-					if _, exists := mapping[src]; !exists {
+					if v, exists := mapping[src]; !exists {
 						mapping[src] = []string{dst}
 					} else {
-						mapping[src] = append(mapping[src], dst)
+						mapping[src] = append(v, dst)
 					}
 				}
 				destinations = append(destinations, dst)

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1056,8 +1056,8 @@ func extractTransformedLabelsFromFuncs(p []parser.Node) map[string][]string {
 				}
 
 				var src string
-				if e, ok := c.Args[3].(*parser.StepInvariantExpr); ok {
-					if lit, ok := e.Expr.(*parser.StringLiteral); ok {
+				if s, ok := c.Args[3].(*parser.StepInvariantExpr); ok {
+					if lit, ok := s.Expr.(*parser.StringLiteral); ok {
 						src = lit.Val
 					}
 				}
@@ -1075,7 +1075,21 @@ func extractTransformedLabelsFromFuncs(p []parser.Node) map[string][]string {
 					mapping = make(map[string][]string, len(c.Args)-3)
 				}
 
-				//TODO loop
+				for _, expr := range c.Args[3:] {
+					if s, ok := expr.(*parser.StepInvariantExpr); ok {
+						if lit, ok := s.Expr.(*parser.StringLiteral); ok && len(lit.Val) > 0 {
+							src := lit.Val
+							if len(dst) > 0 && len(src) > 0 && !slices.Contains(destinations, src) {
+								if _, exists := mapping[src]; !exists {
+									mapping[src] = []string{dst}
+								} else {
+									mapping[src] = append(mapping[src], dst)
+								}
+							}
+							destinations = append(destinations, dst)
+						}
+					}
+				}
 			}
 		}
 	}

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1080,10 +1080,10 @@ func extractTransformedLabelsFromFuncs(p []parser.Node) map[string][]string {
 						if lit, ok := s.Expr.(*parser.StringLiteral); ok && len(lit.Val) > 0 {
 							src := lit.Val
 							if len(dst) > 0 && len(src) > 0 && !slices.Contains(destinations, src) {
-								if _, exists := mapping[src]; !exists {
+								if v, exists := mapping[src]; !exists {
 									mapping[src] = []string{dst}
 								} else {
-									mapping[src] = append(mapping[src], dst)
+									mapping[src] = append(v, dst)
 								}
 							}
 							destinations = append(destinations, dst)

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -200,12 +200,13 @@ type SelectHints struct {
 
 	Step     int64    // Query step size in milliseconds.
 	Func     string   // String representation of surrounding function or aggregation.
-	AllFuncs []string // List of all functions or aggregations up the 'tree'
+	AllFuncs []string // List of all functions or aggregations up the 'tree'.
 
-	Grouping     []string // List of label names used in aggregation.
-	GroupingFunc string   // Function used for the grouping.
-	By           bool     // Indicate whether it is without or by.
-	Range        int64    // Range vector selector range in milliseconds.
+	Grouping                            []string            // List of label names used in aggregation.
+	TransformedLabelsMappingForGrouping map[string][]string // Mapping of all replaced/joined labels derived from label_replace and label_join calls in the innermost aggregation.
+	GroupingFunc                        string              // Function used for the grouping.
+	By                                  bool                // Indicate whether it is without or by.
+	Range                               int64               // Range vector selector range in milliseconds.
 
 	// ShardCount is the total number of shards that series should be split into
 	// at query time. Then, only series in the ShardIndex shard will be returned


### PR DESCRIPTION
The new logic only looks at the innermost aggregation and also discards dependencies between multiple function calls while preserving the call order for the mapping.